### PR TITLE
Add yamllint to cron, pull and push actions

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,8 +1,9 @@
+---
 name: Cron actions
 
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron:  '0 0 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   lint:
@@ -29,6 +30,11 @@ jobs:
           gitlint --version
           # gitlint should ignore Merge commits by default but it does not seem to do it
           gitlint --ignore body-is-missing -c title-max-length.line-length=50 -c ignore-by-title.regex='^Merge(.*)into(.*)'
+
+      - run: |
+          pip3 install yamllint
+          yamllint --version
+          yamllint -d "{extends: default, rules: {line-length: disable}}" .
 
   build:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -1,6 +1,7 @@
+---
 name: Pull actions
 
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
 
 jobs:
@@ -28,6 +29,11 @@ jobs:
           gitlint --version
           # gitlint should ignore Merge commits by default but it does not seem to do it
           gitlint --ignore body-is-missing -c title-max-length.line-length=50 -c ignore-by-title.regex='^Merge(.*)into(.*)'
+
+      - run: |
+          pip3 install yamllint
+          yamllint --version
+          yamllint -d "{extends: default, rules: {line-length: disable}}" .
 
   build:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,6 +1,7 @@
+---
 name: Push actions
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master
@@ -30,6 +31,11 @@ jobs:
           gitlint --version
           # gitlint should ignore Merge commits by default but it does not seem to do it
           gitlint --ignore body-is-missing -c title-max-length.line-length=50 -c ignore-by-title.regex='^Merge(.*)into(.*)'
+
+      - run: |
+          pip3 install yamllint
+          yamllint --version
+          yamllint -d "{extends: default, rules: {line-length: disable}}" .
 
   build:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,6 +1,7 @@
+---
 name: Tag actions
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
Use yamllint to check yaml code, for now line-length check is disabled.
Update files to make sure they comply with yamllint.