### PR TITLE
Run actions on multiple python versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,9 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   build:
     runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - if: github.event_name == 'pull_request'
         uses: "actions/checkout@v2"
@@ -24,7 +27,7 @@ jobs:
 
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       - run: python3 --version
 
       - run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,9 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   lint:
     runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - if: github.event_name == 'pull_request'
         uses: "actions/checkout@v2"
@@ -24,7 +27,7 @@ jobs:
 
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       - run: python3 --version
 
       - run: |

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.x"
+          python-version: "3.9"
       - run: python3 --version
 
       - run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,9 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   test:
     runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - if: github.event_name == 'pull_request'
         uses: "actions/checkout@v2"
@@ -24,7 +27,7 @@ jobs:
 
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       - run: python3 --version
 
       - run: |


### PR DESCRIPTION
Use Python 3.6, 3.7, 3.8 and 3.9 to build, lint and test.