### PR TITLE
Bump aiohttp

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.6.1
+aiohttp>=3.7.4.post0
 black==20.8b1
 codespell==1.17.1
 flake8==3.8.3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
-aiohttp>=3.6.1
+aiohttp>=3.7.4.post0
 coverage==5.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ PACKAGES = find_packages()
 PACKAGE_DATA = {"pyavanza": ["py.typed"]}
 
 REQUIRES = [
-    "aiohttp>=3.6.1",
+    "aiohttp>=3.7.4.post0",
 ]
 
 CLASSIFIERS = [


### PR DESCRIPTION
HACS validation failed and homeassistant seems to use a newer version of aiohttp